### PR TITLE
Display only year if no event parameter is set

### DIFF
--- a/index.php
+++ b/index.php
@@ -82,9 +82,9 @@
             break;
         
         default:
-            $viewWidth = 231;
-            $evtAbbr = "BER";
-            $evtLong = "Berlin";
+            $viewWidth = 195;
+            $evtAbbr = "";
+            $evtLong = "";
             $evtColor = "#2aabe1";
             break;
     }


### PR DESCRIPTION
I would suggest to display only the **year** if no `event` GET parameter is set, instead of setting it to Berlin by default.