### PR TITLE
change builder-preview from iframe to img

### DIFF
--- a/builder/index.html
+++ b/builder/index.html
@@ -11,7 +11,7 @@
     <body>
         <h1>Jugend Hackt Badge Generator</h1>
         <h2>Quickly generate an (inofficial) Jugend Hackt GitHub Badge for your README</h2>
-        
+
         <br>
         <h3>Please select the badge type:</h3>
         <div id="badges">
@@ -48,7 +48,7 @@
 
         <br>
         <h3>Result:</h3>
-        <iframe id="preview"></iframe>
+        <img id="preview"></img>
         <br><br>
         <div id="code">
             <b>URL:</b> <span id="url"></span><br>


### PR DESCRIPTION
This is done to remove the scrollbar, which appears when the image is too long.
![example of the scrollbar at the preview](https://user-images.githubusercontent.com/22817873/66077674-ba7ebd00-e560-11e9-8d35-63d793fde0c5.png)
