### PR TITLE
Alt text for generated markdown badges

### DIFF
--- a/builder/index.js
+++ b/builder/index.js
@@ -141,5 +141,5 @@ function refreshIFrame() {
 	// Fill the HTML attributes with the new URL (in various forms)
 	document.getElementById("preview").src = url;
 	document.getElementById("url").innerHTML = '<a href="' + url + '">'+url+'</a>';
-	document.getElementById("md").innerText = "![](" + url + ")";
+	document.getElementById("md").innerText = "![Jugend hackt " + eventSelected + " " + yearSelected + "](" + url + ")";
 }


### PR DESCRIPTION
All badges should come with a pre-defined alt text for markdown files as it is important for accessibility.