### PR TITLE
Simple typo in "Heidelberg" in the Readme.md (Interesting project, keep it up!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These are the events the generator recognizes:
 - `cgn` - Köln
 - `ffm` - Frankfurt
 - `hal` - Halle
-- `hd` - Heidelbarg
+- `hd` - Heidelberg
 - `hh` - Hamburg
 - `mv` - Mecklenburg-Vorpommern
 - `ulm` - Ulm


### PR DESCRIPTION
fixed a small typo in the Readme. It was saying "Heidelbarg" instead of "Heidelberg"